### PR TITLE
Fix timeseries loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "requests>=2.32.4",
     "obstore>=0.8.2",
 ]
-version = "0.2.77"
+version = "0.2.78"
 classifiers = [
     "Development Status :: 3 - Alpha",          # https://pypi.org/classifiers/
     "Programming Language :: Python :: 3",

--- a/src/lazynwb/timeseries.py
+++ b/src/lazynwb/timeseries.py
@@ -194,7 +194,7 @@ def get_timeseries(
     else:
         path_to_accessor = {
             _format(k): TimeSeries(_file_path=nwb_path, _table_path=_format(k))
-            for k in lazynwb.utils._traverse_internal_paths(file._file)
+            for k in lazynwb.file_io.get_internal_paths(nwb_path)
             if k.split("/")[-1] in ("data", "timestamps")
             and (not search_term or search_term in k)
             # regular timeseries will be a dir with /data and optional /timestamps

--- a/src/lazynwb/timeseries.py
+++ b/src/lazynwb/timeseries.py
@@ -58,6 +58,19 @@ class TimeSeries:
             return (np.arange(len(self.data)) / rate) + starting_time
 
     @property
+    def electrodes(self) -> h5py.Dataset | zarr.Array:
+        try:
+            return self._file[f"{self._table_path}/electrodes"]
+        except KeyError:
+            if self._table_path not in self._file:
+                raise lazynwb.exceptions.InternalPathError(
+                    f"{self._table_path} not found in file"
+                ) from None
+            raise AttributeError(
+                f"{self._table_path} has no electrode data"
+            )
+
+    @property
     def conversion(self) -> float | None:
         return self.data.attrs.get("conversion", None)
 


### PR DESCRIPTION
It seems like `get_timeseries()` was calling a deprecated method, causing it to fail. These changes restore the ability to load timeseries. I also added an `electrodes` property to the `TimeSeries` object so LFP data is fully accessible, and incremented the version number to 0.2.78. I've tested with Zarr NWB files, but not HDF5.